### PR TITLE
Remove redis conditional

### DIFF
--- a/bin/auth.js
+++ b/bin/auth.js
@@ -7,7 +7,10 @@ const config = require("./config"),
   lti = require("ims-lti"),
   RedisNonceStore = require("../node_modules/ims-lti/lib/redis-nonce-store.js"),
   redis = require("redis"),
-  redis_client = redis.createClient(config.redisURL),
+  redis_client =
+    process.env.NODE_ENV === "development"
+      ? require("redis").createClient()
+      : require("redis").createClient(config.redisURL),
   store = new RedisNonceStore(config.client_id, redis_client);
 
 if (!provider) {

--- a/bin/auth.js
+++ b/bin/auth.js
@@ -7,10 +7,7 @@ const config = require("./config"),
   lti = require("ims-lti"),
   RedisNonceStore = require("../node_modules/ims-lti/lib/redis-nonce-store.js"),
   redis = require("redis"),
-  redis_client =
-    process.env.NODE_ENV === "development"
-      ? require("redis").createClient()
-      : require("redis").createClient(config.redisURL),
+  redis_client = require("redis").createClient(config.redisURL),
   store = new RedisNonceStore(config.client_id, redis_client);
 
 if (!provider) {

--- a/bin/config.js
+++ b/bin/config.js
@@ -40,11 +40,11 @@ config.mongoDBs = {
   8374: "conexBlue21",
   8369: "smithBlue21",
   8367: "trinityBlue21",
-  8467: "physics21", 
+  8467: "physics21",
 };
 
 // If we're in a development environment, use the development databasez
-if (process.env.NODE_ENV == "development") {
+if (process.env.NODE_ENV === "development") {
   config.mongoDBs["8310"] = "development";
   config.mongoDBs["8285"] = "development";
 }

--- a/start.js
+++ b/start.js
@@ -4,7 +4,10 @@ if (process.env.NODE_ENV !== "production") {
 
 const express = require("express"),
   config = require("./bin/config"),
-  redis = require("redis").createClient(config.redisURL),
+  redis =
+    process.env.NODE_ENV === "development"
+      ? require("redis").createClient()
+      : require("redis").createClient(config.redisURL),
   modules = require("./routes/modules"),
   session = require("cookie-session"),
   canvas = require("./models/canvas"),

--- a/start.js
+++ b/start.js
@@ -4,10 +4,7 @@ if (process.env.NODE_ENV !== "production") {
 
 const express = require("express"),
   config = require("./bin/config"),
-  redis =
-    process.env.NODE_ENV === "development"
-      ? require("redis").createClient()
-      : require("redis").createClient(config.redisURL),
+  redis = require("redis").createClient(config.redisURL),
   modules = require("./routes/modules"),
   session = require("cookie-session"),
   canvas = require("./models/canvas"),


### PR DESCRIPTION
We can just keep piggy backing off of the heroku ones for now. This makes switching the node_env easier to do regarding the oauth